### PR TITLE
Fix final tool line parsing

### DIFF
--- a/aider/utils.py
+++ b/aider/utils.py
@@ -186,6 +186,7 @@ def split_chat_history_markdown(text, include_tool=False):
 
     append_msg("assistant", assistant)
     append_msg("user", user)
+    append_msg("tool", tool)
 
     if not include_tool:
         messages = [m for m in messages if m["role"] != "tool"]


### PR DESCRIPTION
## Summary
- ensure split_chat_history_markdown preserves final tool message

## Testing
- `ruff check . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mixpanel', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683fbf58e594832d9acedc8eb17e2ee2